### PR TITLE
Pass along region information

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ deploy:
   aws_key: <AWS id key>
   aws_secret: <AWS secret key>
   concurrency: <number of connections> //Optional
+  region: <region> //Optional, see https://github.com/LearnBoost/knox#region
 ```
 
 ### Disable

--- a/index.js
+++ b/index.js
@@ -21,6 +21,7 @@ hexo.extend.deployer.register('s3', function (args, callback) {
       '    aws_key: <aws_key>',
       '    aws_secret: <aws_secret>',
       '    [concurrency]: <concurrency>',
+      '    [region]: <region>          # See https://github.com/LearnBoost/knox#region',
       '',
       'For more help, you can check the docs: ' + 'https://github.com/joshstrange/hexo-deployer-s3'
     ];
@@ -47,6 +48,7 @@ hexo.extend.deployer.register('s3', function (args, callback) {
     , secret: config.aws_secret
     , bucket: config.bucket
     , concurrency: config.concurrency
+    , region: config.region
   }).on('data', function(file) {
     console.log(file.fullPath + ' -> ' + file.url)
   }).on('end', function() {


### PR DESCRIPTION
This PR allows someone to define a `region` key in `_config.yml` so that upload works correctly via `s3-sync`.

Why? [`s3-sync`](https://github.com/hughsk/s3-sync) uses [`knox`](https://github.com/LearnBoost/knox) to handle S3 commands. Unless your are uploading to `us-standard`, the upload will fail because the S3 url won't be correct.
